### PR TITLE
Phase 6: iOS Preview + Siri Completion Runbook

### DIFF
--- a/docs/ANDROID_PREVIEW_WINDOWS.md
+++ b/docs/ANDROID_PREVIEW_WINDOWS.md
@@ -21,6 +21,15 @@ If virtualization is disabled:
 2. Enable Intel VT-x or AMD-V
 3. Save and reboot
 
+## Required Windows Setting: Developer Mode (Flutter plugin symlinks)
+
+Flutter uses **symlinks** for some plugins on Windows. If Windows Developer Mode is disabled, you may see:
+- `Building with plugins requires symlink support`
+
+Fix (recommended to do before anything else):
+1. Settings → Privacy & security → For developers → **Developer Mode** → **On**
+2. Re-run your Flutter command (`flutter pub get`, `flutter run`, etc.)
+
 ## Step 1: Install Flutter
 
 ### Option A: Direct Download (Recommended)
@@ -215,9 +224,6 @@ Get-Content pubspec.yaml | Select-String "name:"
 emulator -list-avds
 
 # Launch Echo_Android_Emu
-emulator -avd Echo_Android_Emu &
-
-# Or use start to run in background
 Start-Process emulator -ArgumentList "-avd", "Echo_Android_Emu"
 ```
 
@@ -392,35 +398,15 @@ $env:GRADLE_OPTS="-Dorg.gradle.daemon=true"
 # org.gradle.caching=true
 ```
 
-## Tomorrow: iOS Simulator Checklist (macOS Required)
+## iOS Preview (macOS Required)
 
-This is a **checklist only** - iOS development requires macOS.
+See:
+- `docs/IOS_PREVIEW_MAC.md`
 
-### Prerequisites
-- [ ] macOS 13 (Ventura) or later
-- [ ] Xcode 15+ installed from App Store (~15GB)
-- [ ] Xcode Command Line Tools: `xcode-select --install`
-- [ ] CocoaPods: `sudo gem install cocoapods`
-- [ ] Accept Xcode license: `sudo xcodebuild -license accept`
+## Siri Shortcuts (iOS)
 
-### Steps
-- [ ] Open Xcode → Preferences → Locations → Set Command Line Tools
-- [ ] Launch iOS Simulator: `open -a Simulator`
-- [ ] Select device: iPhone 15 Pro (or latest)
-- [ ] Navigate to: `cd echo/apps/echo_mobile`
-- [ ] Install pods: `cd ios && pod install && cd ..`
-- [ ] Run app: `flutter run`
-- [ ] Verify: App launches on iOS Simulator
-- [ ] Test: Hot reload works (`r` in terminal)
-
-### iOS-Specific Issues
-- [ ] If build fails: `cd ios && rm -rf Pods Podfile.lock && pod install`
-- [ ] If signing issue: Open `ios/Runner.xcworkspace` in Xcode → Signing & Capabilities → Select team
-- [ ] If simulator not found: `flutter devices` → Check Xcode path
-
-### Resources
-- Xcode download: https://developer.apple.com/xcode/
-- Flutter iOS setup: https://docs.flutter.dev/get-started/install/macos
+See:
+- `docs/SIRI_SHORTCUTS_INTEGRATION.md`
 
 ---
 
@@ -453,4 +439,4 @@ This is a **checklist only** - iOS development requires macOS.
 
 ---
 
-*Last updated: Phase 4 (Android Windows Preview)*
+*Last updated: Phase 6 (Windows Android + macOS iOS runbooks)*

--- a/docs/IOS_PREVIEW_MAC.md
+++ b/docs/IOS_PREVIEW_MAC.md
@@ -1,0 +1,236 @@
+# Echo iOS Preview on macOS
+
+This guide provides **exact, copy/paste steps** to run Echo on a macOS machine using Xcode + the iOS Simulator, and (optionally) on a physical iPhone.
+
+If you are primarily trying to preview the UI quickly, start with Android on Windows:
+- `docs/ANDROID_PREVIEW_WINDOWS.md`
+
+If you want to complete Siri Shortcuts on iOS, see:
+- `docs/SIRI_SHORTCUTS_INTEGRATION.md`
+
+## What You Can / Can’t Test
+
+- ✅ iOS Simulator: app launch + UI navigation + hot reload
+- ✅ Physical iPhone: everything the simulator can do + device-only hardware checks
+- ❌ Siri voice invocation (“Hey Siri, …”): **requires a physical iPhone**
+
+## Prerequisites
+
+### Required
+- macOS 13+ (Ventura) recommended
+- Xcode 15+ installed
+- Flutter **3.27.0+** (Dart 3.6.0+)
+
+### Recommended
+- FVM (Flutter Version Manager) to match the repo’s pinned Flutter version
+- CocoaPods (required for iOS builds with plugins)
+
+## Step 0: Install Xcode + Command Line Tools
+
+1. Install Xcode
+   - App Store → **Xcode** → Install
+   - Launch Xcode once after install
+
+2. Install/confirm Command Line Tools
+
+```bash
+xcode-select --install
+```
+
+3. Accept Xcode license
+
+```bash
+sudo xcodebuild -license accept
+```
+
+4. Ensure Xcode is the selected developer directory
+
+```bash
+sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+xcodebuild -version
+```
+
+5. In Xcode, set Command Line Tools:
+   - Xcode → **Settings…** (or Preferences)
+   - **Locations** → **Command Line Tools** → select the latest Xcode
+
+## Step 1: Install Flutter (Recommended: FVM)
+
+From a fresh terminal:
+
+```bash
+# Install fvm
+dart pub global activate fvm
+
+# In the repo root
+cd ~/echo
+
+# Install and use the pinned Flutter version
+fvm install
+fvm use
+
+# Verify
+fvm flutter --version
+```
+
+If you are NOT using FVM, verify:
+
+```bash
+flutter --version
+```
+
+## Step 2: Clone / Update Repo
+
+```bash
+# Clone
+git clone https://github.com/yosiwizman/echo.git
+cd echo
+
+# Ensure main is up to date
+git checkout main
+git pull origin main
+```
+
+## Step 3: Get Flutter Dependencies
+
+```bash
+cd apps/echo_mobile
+
+# With FVM
+fvm flutter pub get
+
+# Without FVM
+# flutter pub get
+```
+
+## Step 4: Install CocoaPods + iOS Pods
+
+### 4.1 Install CocoaPods (one-time)
+
+Option A (Homebrew):
+
+```bash
+brew install cocoapods
+```
+
+Option B (RubyGems):
+
+```bash
+sudo gem install cocoapods
+```
+
+Verify:
+
+```bash
+pod --version
+```
+
+### 4.2 Install Pods for this repo
+
+```bash
+cd ios
+pod install
+cd ..
+```
+
+**Important:** `pod install` should create `ios/Runner.xcworkspace`.
+
+## Step 5: Run on iOS Simulator
+
+1. Start the simulator
+
+```bash
+open -a Simulator
+```
+
+2. Verify Flutter sees the simulator
+
+```bash
+cd ~/echo/apps/echo_mobile
+fvm flutter devices
+```
+
+3. Run
+
+```bash
+# From apps/echo_mobile
+fvm flutter run
+```
+
+Expected:
+- Xcode build runs
+- The app launches on the simulator
+- Hot reload works (`r` in the terminal)
+
+## Step 6: Run on a Physical iPhone (Optional)
+
+### 6.1 Connect and trust
+1. Plug in iPhone via USB
+2. Unlock iPhone → tap **Trust**
+3. In Xcode: Window → **Devices and Simulators** → confirm the device appears
+
+### 6.2 Fix code signing (if needed)
+If `flutter run` fails with signing errors:
+1. Open:
+
+```bash
+open ios/Runner.xcworkspace
+```
+
+2. In Xcode:
+   - Select **Runner** project (left sidebar)
+   - Select **Runner** target
+   - Signing & Capabilities → select a **Team**
+   - Keep “Automatically manage signing” enabled
+
+If Xcode complains the bundle ID is not available, set a unique one locally (do not commit):
+- `apps/echo_mobile/ios/Flutter/Base.xcconfig` → update `APP_BUNDLE_IDENTIFIER=`
+
+### 6.3 Run on device
+
+```bash
+cd ~/echo/apps/echo_mobile
+fvm flutter devices
+fvm flutter run -d <YOUR_DEVICE_ID>
+```
+
+## Siri Shortcuts (iOS) — Completion
+
+Siri Shortcuts are **not fully complete in the repo** without Xcode GUI steps.
+Follow:
+- `docs/SIRI_SHORTCUTS_INTEGRATION.md` → “macOS / Xcode completion checklist”
+
+## Common Issues & Fixes
+
+### Issue: `flutter doctor` shows Xcode errors
+
+```bash
+fvm flutter doctor -v
+sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+```
+
+### Issue: CocoaPods “sandbox is not in sync”
+
+```bash
+cd ios
+pod install
+cd ..
+```
+
+### Issue: Pods / build failures after dependency changes
+
+```bash
+cd ios
+rm -rf Pods Podfile.lock
+pod install
+cd ..
+
+fvm flutter clean
+fvm flutter pub get
+fvm flutter run
+```
+
+### Issue: “No devices found” (simulator)
+- Ensure Xcode is installed and opened once
+- Ensure the simulator app is running: `open -a Simulator`
+- Re-run: `fvm flutter devices`

--- a/docs/PREVIEW.md
+++ b/docs/PREVIEW.md
@@ -38,10 +38,15 @@ This command validates your Flutter installation and shows missing dependencies.
 
 ## Quick Start
 
+### Platform Runbooks (Recommended)
+- **Windows + Android:** `docs/ANDROID_PREVIEW_WINDOWS.md`
+- **macOS + iOS:** `docs/IOS_PREVIEW_MAC.md`
+- **iOS Siri Shortcuts:** `docs/SIRI_SHORTCUTS_INTEGRATION.md`
+
 ### 1. Clone the Repository
 
 ```bash
-git checkout https://github.com/yosiwizman/echo.git
+git clone https://github.com/yosiwizman/echo.git
 cd echo
 ```
 
@@ -313,4 +318,4 @@ flutter build ios --release
 
 ---
 
-*Last updated: Phase 3 (Local Preview Build)*
+*Last updated: Phase 6 (Platform Runbooks + iOS Preview)*

--- a/docs/SIRI_SHORTCUTS_INTEGRATION.md
+++ b/docs/SIRI_SHORTCUTS_INTEGRATION.md
@@ -142,22 +142,22 @@ NotificationCenter.default.addObserver(
     guard let controller = window?.rootViewController as? FlutterViewController else { return }
     
     let methodChannel = FlutterMethodChannel(
-        name: "com.echo/siri_shortcuts",
+        name: "com.echo/siri",
         binaryMessenger: controller.binaryMessenger
     )
     
-    methodChannel.invokeMethod("startRecording", arguments: ["source": "siri"])
+    methodChannel.invokeMethod("startSession", arguments: ["source": "siri_shortcut"])
 }
 
 @objc private func handleStopRecordingShortcut(notification: Notification) {
     guard let controller = window?.rootViewController as? FlutterViewController else { return }
     
     let methodChannel = FlutterMethodChannel(
-        name: "com.echo/siri_shortcuts",
+        name: "com.echo/siri",
         binaryMessenger: controller.binaryMessenger
     )
     
-    methodChannel.invokeMethod("stopRecording", arguments: nil)
+    methodChannel.invokeMethod("stopSession", arguments: nil)
 }
 ```
 
@@ -173,7 +173,7 @@ import 'package:omi/providers/capture_provider.dart';
 import 'package:omi/utils/logger.dart';
 
 class SiriShortcutsService {
-  static const MethodChannel _channel = MethodChannel('com.echo/siri_shortcuts');
+  static const MethodChannel _channel = MethodChannel('com.echo/siri');
   final CaptureProvider _captureProvider;
   
   SiriShortcutsService(this._captureProvider) {
@@ -183,10 +183,10 @@ class SiriShortcutsService {
   Future<void> _handleMethod(MethodCall call) async {
     try {
       switch (call.method) {
-        case 'startRecording':
+        case 'startSession':
           await _handleStartRecording(call.arguments);
           break;
-        case 'stopRecording':
+        case 'stopSession':
           await _handleStopRecording();
           break;
         default:
@@ -556,10 +556,13 @@ Since the Omni white-label code is on `phase-1-omi-white-label`, you need to:
 
 ```bash
 cd ~/echo/apps/echo_mobile
+cd ios && pod install && cd ..
 open ios/Runner.xcworkspace
 ```
 
-**⚠️ Important:** Open `.xcworkspace`, NOT `.xcodeproj`
+**⚠️ Important:** Open `.xcworkspace`, NOT `.xcodeproj` (CocoaPods uses the workspace).
+
+If `Runner.xcworkspace` is missing, re-run `pod install` (above).
 
 ### Step 2: Create Intents.intentdefinition File
 
@@ -597,7 +600,12 @@ open ios/Runner.xcworkspace
 
 ### Step 3: Update IntentHandler.swift
 
-Replace placeholder code in `ios/Runner/IntentHandler.swift`:
+1. Ensure `IntentHandler.swift` is in the Xcode project and included in the target:
+   - Xcode menu: **File → Add Files to "Runner"…**
+   - Select: `apps/echo_mobile/ios/Runner/IntentHandler.swift`
+   - In the dialog, ensure **Add to targets:** ✅ Runner
+
+2. Replace placeholder code in `ios/Runner/IntentHandler.swift`:
 
 ```swift
 // Replace this section:


### PR DESCRIPTION
## Summary
This PR adds Phase 6 platform runbooks and tightens Siri Shortcuts completion guidance.

### What’s included
- New: `docs/IOS_PREVIEW_MAC.md` (macOS + iOS Simulator + physical iPhone runbook)
- Update: `docs/PREVIEW.md`
  - Links to platform runbooks
  - Fixes the Quick Start command (`git clone` instead of `git checkout <url>`)
- Update: `docs/ANDROID_PREVIEW_WINDOWS.md`
  - Adds a clear Windows Developer Mode note for Flutter plugin symlink support
  - Links out to the new iOS runbook and the Siri doc (no more duplicated iOS checklist)
- Update: `docs/SIRI_SHORTCUTS_INTEGRATION.md`
  - Aligns method-channel naming with current code (`com.echo/siri`, `startSession` / `stopSession`)
  - Makes Xcode steps more deterministic (`pod install` before opening workspace, explicit “Add Files to Runner…” + target membership)

## Notes
- Siri voice invocation requires a **physical iPhone**; simulator cannot test it.
- Siri remains partially complete until the Xcode GUI steps are performed (intent definition + capabilities + wiring).

## Testing
Docs-only changes; no runtime changes in this PR.