### PR TITLE
feat(voice): implement Voice v1 (STT + TTS) end-to-end

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,17 @@ The Brain Chat API provides conversational AI endpoints at `/v1/brain/*`:
 
 See [docs/brain_api.md](docs/brain_api.md) for full documentation.
 
+### Voice v1 (STT + TTS)
+Voice endpoints enable speech-to-text input and text-to-speech output:
+- `POST /v1/brain/stt` — Transcribe audio to text (multipart/form-data)
+- `POST /v1/brain/tts` — Convert text to speech (returns base64 audio)
+
+The web UI includes:
+- **Mic button** — Click to record, click to stop and transcribe
+- **Auto-play toggle** — 🔊 in header to auto-play AI responses
+
+See [docs/ops/voice_v1.md](docs/ops/voice_v1.md) for full documentation.
+
 ### Running the Mobile App
 
 ```bash

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,13 +3,16 @@ import { Header } from './components/Header';
 import { ChatMessage } from './components/ChatMessage';
 import { ChatInput } from './components/ChatInput';
 import { PinModal } from './components/PinModal';
+import { VoiceButton } from './components/VoiceButton';
 import { useChat } from './hooks/useChat';
 import { useHealth } from './hooks/useHealth';
 import { useAuth } from './hooks/useAuth';
+import { useVoice } from './hooks/useVoice';
 import { DEFAULT_ENVIRONMENT, type Environment } from './config';
 
 const ENV_STORAGE_KEY = 'echo-environment';
 const STREAM_STORAGE_KEY = 'echo-streaming';
+const VOICE_AUTOPLAY_KEY = 'echo-voice-autoplay';
 
 function loadEnvironment(): Environment {
   try {
@@ -30,9 +33,21 @@ function loadStreaming(): boolean {
   }
 }
 
+function loadVoiceAutoPlay(): boolean {
+  try {
+    const stored = localStorage.getItem(VOICE_AUTOPLAY_KEY);
+    // Default to true for voice auto-play
+    return stored === null ? true : stored === 'true';
+  } catch {
+    return true;
+  }
+}
+
 export default function App() {
   const [environment, setEnvironment] = useState<Environment>(loadEnvironment);
   const [streamingEnabled, setStreamingEnabled] = useState(loadStreaming);
+  const [voiceAutoPlay, setVoiceAutoPlay] = useState(loadVoiceAutoPlay);
+  const [pendingVoiceText, setPendingVoiceText] = useState<string | null>(null);
   const [showPinModal, setShowPinModal] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
@@ -51,6 +66,19 @@ export default function App() {
     handleAuthRequired
   );
 
+  // Voice input hook
+  const handleTranscription = useCallback((text: string) => {
+    // Send transcribed text to chat
+    sendMessage(text);
+  }, [sendMessage]);
+
+  const voice = useVoice({
+    environment,
+    authToken: auth.token,
+    onAuthRequired: handleAuthRequired,
+    onTranscription: handleTranscription,
+  });
+
   const handleLogin = useCallback(async (pin: string) => {
     const success = await auth.login(pin);
     if (success) {
@@ -67,6 +95,25 @@ export default function App() {
     localStorage.setItem(STREAM_STORAGE_KEY, String(streamingEnabled));
   }, [streamingEnabled]);
 
+  useEffect(() => {
+    localStorage.setItem(VOICE_AUTOPLAY_KEY, String(voiceAutoPlay));
+  }, [voiceAutoPlay]);
+
+  // Auto-play TTS for new assistant messages when enabled
+  useEffect(() => {
+    if (!voiceAutoPlay || messages.length === 0) return;
+    
+    const lastMessage = messages[messages.length - 1];
+    // Only play if it's an assistant message and not loading
+    if (lastMessage.role === 'assistant' && !isLoading && lastMessage.content) {
+      // Check if this is a new message we haven't played yet
+      if (pendingVoiceText !== lastMessage.content && !lastMessage.content.startsWith('Error:')) {
+        setPendingVoiceText(lastMessage.content);
+        voice.playTTS(lastMessage.content);
+      }
+    }
+  }, [messages, isLoading, voiceAutoPlay, pendingVoiceText, voice]);
+
   // Auto-scroll to bottom
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -79,6 +126,8 @@ export default function App() {
         onEnvironmentChange={setEnvironment}
         streamingEnabled={streamingEnabled}
         onStreamingChange={setStreamingEnabled}
+        voiceAutoPlay={voiceAutoPlay}
+        onVoiceAutoPlayChange={setVoiceAutoPlay}
         healthStatus={healthStatus}
         onHealthCheck={checkHealth}
         onClearChat={clearMessages}
@@ -123,12 +172,25 @@ export default function App() {
 
       <footer className="bg-white border-t border-gray-200 p-4">
         <div className="max-w-4xl mx-auto">
-          <ChatInput
-            onSend={sendMessage}
-            onCancel={cancelRequest}
-            disabled={healthStatus === 'error'}
-            isLoading={isLoading}
-          />
+          <div className="flex items-end gap-2">
+            <VoiceButton
+              recordingState={voice.recordingState}
+              onStartRecording={voice.startRecording}
+              onStopRecording={voice.stopRecording}
+              disabled={healthStatus === 'error' || isLoading}
+            />
+            <div className="flex-1">
+              <ChatInput
+                onSend={sendMessage}
+                onCancel={cancelRequest}
+                disabled={healthStatus === 'error'}
+                isLoading={isLoading}
+              />
+            </div>
+          </div>
+          {voice.error && (
+            <p className="text-xs text-red-500 mt-1">Voice: {voice.error}</p>
+          )}
           {healthStatus === 'error' && (
             <p className="text-xs text-red-500 mt-2 text-center">
               Cannot send messages while disconnected from backend

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -6,6 +6,8 @@ interface Props {
   onEnvironmentChange: (env: Environment) => void;
   streamingEnabled: boolean;
   onStreamingChange: (enabled: boolean) => void;
+  voiceAutoPlay: boolean;
+  onVoiceAutoPlayChange: (enabled: boolean) => void;
   healthStatus: HealthStatus;
   onHealthCheck: () => void;
   onClearChat: () => void;
@@ -102,6 +104,8 @@ export function Header({
   onEnvironmentChange,
   streamingEnabled,
   onStreamingChange,
+  voiceAutoPlay,
+  onVoiceAutoPlayChange,
   healthStatus,
   onHealthCheck,
   onClearChat,
@@ -157,6 +161,17 @@ export function Header({
               type="checkbox"
               checked={streamingEnabled}
               onChange={(e) => onStreamingChange(e.target.checked)}
+              className="w-4 h-4 text-echo-500 rounded focus:ring-echo-500"
+            />
+          </label>
+
+          {/* Voice Auto-Play Toggle */}
+          <label className="flex items-center gap-2 cursor-pointer" title="Auto-play voice replies">
+            <span className="text-sm text-gray-600">🔊</span>
+            <input
+              type="checkbox"
+              checked={voiceAutoPlay}
+              onChange={(e) => onVoiceAutoPlayChange(e.target.checked)}
               className="w-4 h-4 text-echo-500 rounded focus:ring-echo-500"
             />
           </label>

--- a/apps/web/src/components/VoiceButton.tsx
+++ b/apps/web/src/components/VoiceButton.tsx
@@ -1,0 +1,118 @@
+import type { RecordingState } from '../hooks/useVoice';
+
+interface VoiceButtonProps {
+  recordingState: RecordingState;
+  onStartRecording: () => void;
+  onStopRecording: () => void;
+  disabled?: boolean;
+}
+
+export function VoiceButton({
+  recordingState,
+  onStartRecording,
+  onStopRecording,
+  disabled = false,
+}: VoiceButtonProps) {
+  const isRecording = recordingState === 'recording';
+  const isProcessing = recordingState === 'processing';
+  const isDisabled = disabled || isProcessing;
+
+  const handleClick = () => {
+    if (isDisabled) return;
+    
+    if (isRecording) {
+      onStopRecording();
+    } else {
+      onStartRecording();
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={isDisabled}
+      className={`
+        relative p-3 rounded-full transition-all duration-200
+        focus:outline-none focus:ring-2 focus:ring-offset-2
+        ${isRecording
+          ? 'bg-red-500 hover:bg-red-600 text-white focus:ring-red-500'
+          : isProcessing
+          ? 'bg-gray-400 text-white cursor-wait'
+          : isDisabled
+          ? 'bg-gray-200 text-gray-400 cursor-not-allowed'
+          : 'bg-cyan-500 hover:bg-cyan-600 text-white focus:ring-cyan-500'
+        }
+      `}
+      title={
+        isRecording
+          ? 'Click to stop recording'
+          : isProcessing
+          ? 'Processing audio...'
+          : 'Click to start voice input'
+      }
+    >
+      {/* Microphone Icon */}
+      {!isRecording && !isProcessing && (
+        <svg
+          className="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z"
+          />
+        </svg>
+      )}
+
+      {/* Stop Icon (when recording) */}
+      {isRecording && (
+        <svg
+          className="w-5 h-5"
+          fill="currentColor"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <rect x="6" y="6" width="12" height="12" rx="1" />
+        </svg>
+      )}
+
+      {/* Spinner (when processing) */}
+      {isProcessing && (
+        <svg
+          className="w-5 h-5 animate-spin"
+          fill="none"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle
+            className="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="4"
+          />
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+          />
+        </svg>
+      )}
+
+      {/* Recording pulse indicator */}
+      {isRecording && (
+        <span className="absolute -top-1 -right-1 flex h-3 w-3">
+          <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75" />
+          <span className="relative inline-flex rounded-full h-3 w-3 bg-red-500" />
+        </span>
+      )}
+    </button>
+  );
+}

--- a/apps/web/src/config.ts
+++ b/apps/web/src/config.ts
@@ -21,6 +21,8 @@ export const API_ENDPOINTS = {
   health: '/health',
   chat: '/v1/brain/chat',
   chatStream: '/v1/brain/chat/stream',
+  stt: '/v1/brain/stt',
+  tts: '/v1/brain/tts',
   version: '/version',
   authLogin: '/v1/auth/login',
 } as const;

--- a/apps/web/src/hooks/useAuth.test.ts
+++ b/apps/web/src/hooks/useAuth.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @vitest-environment jsdom
+ */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { getAuthToken, clearAuthToken } from './useAuth';
 

--- a/apps/web/src/hooks/useVoice.ts
+++ b/apps/web/src/hooks/useVoice.ts
@@ -1,0 +1,272 @@
+import { useState, useCallback, useRef } from 'react';
+import type { STTResponse, TTSResponse } from '../types';
+import { BACKEND_URLS, API_ENDPOINTS, type Environment } from '../config';
+
+export type RecordingState = 'idle' | 'recording' | 'processing';
+
+interface UseVoiceOptions {
+  environment: Environment;
+  authToken: string | null;
+  onAuthRequired?: () => void;
+  onTranscription?: (text: string) => void;
+}
+
+export function useVoice({
+  environment,
+  authToken,
+  onAuthRequired,
+  onTranscription,
+}: UseVoiceOptions) {
+  const [recordingState, setRecordingState] = useState<RecordingState>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const audioChunksRef = useRef<Blob[]>([]);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const authTokenRef = useRef(authToken);
+  
+  // Keep authToken ref updated
+  authTokenRef.current = authToken;
+
+  const startRecording = useCallback(async () => {
+    setError(null);
+    
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      
+      // Prefer webm if supported, fallback to other formats
+      const mimeType = MediaRecorder.isTypeSupported('audio/webm')
+        ? 'audio/webm'
+        : MediaRecorder.isTypeSupported('audio/mp4')
+        ? 'audio/mp4'
+        : 'audio/wav';
+      
+      const mediaRecorder = new MediaRecorder(stream, { mimeType });
+      mediaRecorderRef.current = mediaRecorder;
+      audioChunksRef.current = [];
+      
+      mediaRecorder.ondataavailable = (event) => {
+        if (event.data.size > 0) {
+          audioChunksRef.current.push(event.data);
+        }
+      };
+      
+      mediaRecorder.onstop = async () => {
+        // Stop all tracks
+        stream.getTracks().forEach(track => track.stop());
+        
+        // Process recorded audio
+        const audioBlob = new Blob(audioChunksRef.current, { type: mimeType });
+        await sendToSTT(audioBlob, mimeType);
+      };
+      
+      mediaRecorder.start();
+      setRecordingState('recording');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to access microphone';
+      setError(message);
+      setRecordingState('idle');
+    }
+  }, []);
+
+  const stopRecording = useCallback(() => {
+    if (mediaRecorderRef.current && recordingState === 'recording') {
+      setRecordingState('processing');
+      mediaRecorderRef.current.stop();
+    }
+  }, [recordingState]);
+
+  const sendToSTT = async (audioBlob: Blob, mimeType: string) => {
+    const baseUrl = BACKEND_URLS[environment];
+    const url = `${baseUrl}${API_ENDPOINTS.stt}`;
+    
+    try {
+      // Build multipart form data
+      const formData = new FormData();
+      const extension = mimeType.includes('webm') ? 'webm' 
+        : mimeType.includes('mp4') ? 'm4a' 
+        : 'wav';
+      formData.append('file', audioBlob, `recording.${extension}`);
+      
+      // Build headers with auth
+      const headers: Record<string, string> = {};
+      const currentToken = authTokenRef.current;
+      if (currentToken) {
+        headers['Authorization'] = `Bearer ${currentToken}`;
+      }
+      
+      const response = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: formData,
+        credentials: 'omit',
+        mode: 'cors',
+      });
+      
+      if (response.status === 401) {
+        onAuthRequired?.();
+        setError('Authentication required');
+        setRecordingState('idle');
+        return;
+      }
+      
+      if (!response.ok) {
+        let errorMessage = `HTTP ${response.status}`;
+        try {
+          const errorBody = await response.json();
+          if (errorBody.detail?.error?.message) {
+            errorMessage = errorBody.detail.error.message;
+          }
+        } catch {
+          // Ignore JSON parse errors
+        }
+        throw new Error(errorMessage);
+      }
+      
+      const data: STTResponse = await response.json();
+      
+      if (data.ok && data.text) {
+        onTranscription?.(data.text);
+      } else {
+        setError('No transcription returned');
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'STT request failed';
+      setError(message);
+    } finally {
+      setRecordingState('idle');
+    }
+  };
+
+  const playTTS = useCallback(async (text: string): Promise<void> => {
+    if (!text.trim()) return;
+    
+    const baseUrl = BACKEND_URLS[environment];
+    const url = `${baseUrl}${API_ENDPOINTS.tts}`;
+    
+    try {
+      setIsPlaying(true);
+      setError(null);
+      
+      // Build headers with auth
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+      };
+      const currentToken = authTokenRef.current;
+      if (currentToken) {
+        headers['Authorization'] = `Bearer ${currentToken}`;
+      }
+      
+      const response = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ text }),
+        credentials: 'omit',
+        mode: 'cors',
+      });
+      
+      if (response.status === 401) {
+        onAuthRequired?.();
+        setError('Authentication required');
+        setIsPlaying(false);
+        return;
+      }
+      
+      if (!response.ok) {
+        let errorMessage = `HTTP ${response.status}`;
+        try {
+          const errorBody = await response.json();
+          if (errorBody.detail?.error?.message) {
+            errorMessage = errorBody.detail.error.message;
+          }
+        } catch {
+          // Ignore JSON parse errors
+        }
+        throw new Error(errorMessage);
+      }
+      
+      const data: TTSResponse = await response.json();
+      
+      if (data.ok && data.audio_base64) {
+        // Decode base64 and create audio element
+        const audioBytes = base64ToArrayBuffer(data.audio_base64);
+        const audioBlob = new Blob([audioBytes], { type: data.mime_type });
+        const audioUrl = URL.createObjectURL(audioBlob);
+        
+        // Stop any existing playback
+        if (audioRef.current) {
+          audioRef.current.pause();
+          URL.revokeObjectURL(audioRef.current.src);
+        }
+        
+        // Create and play audio
+        const audio = new Audio(audioUrl);
+        audioRef.current = audio;
+        
+        audio.onended = () => {
+          setIsPlaying(false);
+          URL.revokeObjectURL(audioUrl);
+        };
+        
+        audio.onerror = () => {
+          setIsPlaying(false);
+          setError('Failed to play audio');
+          URL.revokeObjectURL(audioUrl);
+        };
+        
+        await audio.play();
+      } else {
+        setError('No audio returned');
+        setIsPlaying(false);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'TTS request failed';
+      setError(message);
+      setIsPlaying(false);
+    }
+  }, [environment, onAuthRequired]);
+
+  const stopPlayback = useCallback(() => {
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current.currentTime = 0;
+      setIsPlaying(false);
+    }
+  }, []);
+
+  const cancelRecording = useCallback(() => {
+    if (mediaRecorderRef.current && recordingState === 'recording') {
+      // Stop without processing
+      const stream = mediaRecorderRef.current.stream;
+      mediaRecorderRef.current.ondataavailable = null;
+      mediaRecorderRef.current.onstop = null;
+      mediaRecorderRef.current.stop();
+      stream.getTracks().forEach(track => track.stop());
+      setRecordingState('idle');
+    }
+  }, [recordingState]);
+
+  return {
+    recordingState,
+    isPlaying,
+    error,
+    startRecording,
+    stopRecording,
+    cancelRecording,
+    playTTS,
+    stopPlayback,
+  };
+}
+
+/**
+ * Convert base64 string to ArrayBuffer.
+ */
+function base64ToArrayBuffer(base64: string): ArrayBuffer {
+  const binaryString = atob(base64);
+  const bytes = new Uint8Array(binaryString.length);
+  for (let i = 0; i < binaryString.length; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  return bytes.buffer;
+}

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -72,3 +72,32 @@ export interface StreamChunk {
   metadata?: ResponseMetadata;
   error?: string;
 }
+
+/**
+ * Response from STT (speech-to-text) endpoint.
+ */
+export interface STTResponse {
+  ok: boolean;
+  text: string;
+  duration_seconds?: number;
+  runtime?: RuntimeMetadata;
+}
+
+/**
+ * Request for TTS (text-to-speech) endpoint.
+ */
+export interface TTSRequest {
+  text: string;
+  voice?: string;
+  format?: string;
+}
+
+/**
+ * Response from TTS (text-to-speech) endpoint.
+ */
+export interface TTSResponse {
+  ok: boolean;
+  audio_base64: string;
+  mime_type: string;
+  runtime?: RuntimeMetadata;
+}

--- a/docs/ops/voice_v1.md
+++ b/docs/ops/voice_v1.md
@@ -1,0 +1,146 @@
+# Voice v1 (STT + TTS)
+
+Voice v1 provides speech-to-text (STT) and text-to-speech (TTS) capabilities for Echo Chat using OpenAI's Audio API.
+
+## Architecture
+
+```
+User speaks → Mic Button → MediaRecorder → /v1/brain/stt → Transcribed text
+     ↓                                                           ↓
+Headphones ← Audio playback ← /v1/brain/tts ← Assistant text ← /v1/brain/chat
+```
+
+## Endpoints
+
+### POST /v1/brain/stt
+Speech-to-text transcription.
+
+**Request:**
+- Content-Type: `multipart/form-data`
+- Body: `file` field with audio (webm, wav, mp3, m4a, ogg, flac)
+- Max size: 25MB
+
+**Response:**
+```json
+{
+  "ok": true,
+  "text": "transcribed text here",
+  "duration_seconds": 3.5,
+  "runtime": {
+    "trace_id": "uuid",
+    "provider": "openai",
+    "env": "staging",
+    "git_sha": "abc123",
+    "build_time": "2026-01-01T00:00:00Z"
+  }
+}
+```
+
+### POST /v1/brain/tts
+Text-to-speech synthesis.
+
+**Request:**
+```json
+{
+  "text": "Hello, how can I help you?",
+  "voice": "alloy",  // optional
+  "format": "mp3"    // optional
+}
+```
+
+**Response:**
+```json
+{
+  "ok": true,
+  "audio_base64": "base64-encoded-audio-bytes",
+  "mime_type": "audio/mpeg",
+  "runtime": { ... }
+}
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OPENAI_STT_MODEL` | `gpt-4o-mini-transcribe` | Model for speech-to-text |
+| `OPENAI_TTS_MODEL` | `gpt-4o-mini-tts` | Model for text-to-speech |
+| `OPENAI_TTS_VOICE` | `alloy` | Default TTS voice |
+| `OPENAI_TTS_FORMAT` | `mp3` | Default audio format |
+| `OPENAI_API_KEY` | (required) | OpenAI API key |
+| `ECHO_VOICE_PROVIDER` | (auto) | Force `stub` or `openai` |
+
+### Available Voices
+- `alloy` - Neutral, balanced
+- `echo` - Deep, warm
+- `fable` - Expressive
+- `onyx` - Authoritative
+- `nova` - Friendly
+- `shimmer` - Clear, bright
+
+### Available Formats
+- `mp3` - MPEG audio (default, widely supported)
+- `opus` - Opus codec (smaller, good quality)
+- `aac` - AAC audio
+- `flac` - Lossless
+- `wav` - Uncompressed
+- `pcm` - Raw PCM
+
+## Authentication
+
+Both `/stt` and `/tts` endpoints require authentication when `AUTH_REQUIRED=true`:
+- Include `Authorization: Bearer <jwt>` header
+- Token obtained via `/v1/auth/login`
+
+## Web UI Usage
+
+1. **Voice Input**: Click the microphone button (cyan) to start recording
+2. **Stop Recording**: Click again (red) to stop and transcribe
+3. **Auto-Play**: Enable 🔊 toggle in header to auto-play assistant replies
+4. **Browser Permission**: Grant microphone access when prompted
+
+## Browser Permissions
+
+The web app requires microphone permission for voice input:
+
+**Chrome/Edge:**
+- Click padlock icon → Site settings → Microphone: Allow
+
+**Firefox:**
+- Click padlock icon → More Information → Permissions → Microphone: Allow
+
+**Safari:**
+- Safari → Settings → Websites → Microphone → Allow
+
+## Privacy
+
+- **Audio content is NEVER logged** on backend
+- Only metadata is logged: trace_id, audio size, duration, content type
+- **Transcribed text is NEVER logged** on backend
+- Audio is processed transiently and not stored
+
+## Testing on Staging
+
+1. Navigate to https://echo-web-staging-zxuvsjb5qa-ew.a.run.app
+2. Login with PIN when prompted
+3. Click mic button → speak → click stop
+4. Your speech is transcribed and sent to chat
+5. With 🔊 enabled, hear the AI response
+
+## Error Handling
+
+| Error Code | HTTP Status | Description |
+|------------|-------------|-------------|
+| `auth_required` | 401 | Missing or invalid JWT |
+| `invalid_audio_format` | 400 | Unsupported audio type |
+| `empty_file` | 400 | Audio file is empty |
+| `file_too_large` | 413 | Exceeds 25MB limit |
+| `rate_limit` | 429 | OpenAI rate limit |
+| `timeout` | 504 | Request timed out |
+| `upstream_error` | 502 | OpenAI API error |
+
+## Stub Mode (CI)
+
+For testing without OpenAI:
+- Set `ECHO_VOICE_PROVIDER=stub`
+- STT returns: "Echo Voice (stub): transcribed X bytes of audio."
+- TTS returns: minimal valid MP3 audio

--- a/services/echo_backend/models/brain.py
+++ b/services/echo_backend/models/brain.py
@@ -86,3 +86,28 @@ class BrainHealthResponse(BaseModel):
     time: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="Server time")
     version: str = Field(default="1.0.0", description="API version")
     provider: str = Field(description="Active brain provider")
+
+
+# Voice API models (STT + TTS)
+
+class STTResponse(BaseModel):
+    """Response from speech-to-text transcription."""
+    ok: bool = Field(default=True, description="Request success status")
+    text: str = Field(description="Transcribed text from audio")
+    duration_seconds: Optional[float] = Field(default=None, description="Audio duration in seconds")
+    runtime: Optional[RuntimeMetadata] = Field(default=None, description="Runtime metadata for observability")
+
+
+class TTSRequest(BaseModel):
+    """Request for text-to-speech synthesis."""
+    text: str = Field(description="Text to convert to speech", min_length=1, max_length=4096)
+    voice: Optional[str] = Field(default=None, description="Voice to use (default: alloy)")
+    format: Optional[str] = Field(default=None, description="Audio format (default: mp3)")
+
+
+class TTSResponse(BaseModel):
+    """Response from text-to-speech synthesis."""
+    ok: bool = Field(default=True, description="Request success status")
+    audio_base64: str = Field(description="Base64-encoded audio data")
+    mime_type: str = Field(description="MIME type of the audio (e.g., audio/mpeg)")
+    runtime: Optional[RuntimeMetadata] = Field(default=None, description="Runtime metadata for observability")

--- a/services/echo_backend/models/brain_contract_v1.json
+++ b/services/echo_backend/models/brain_contract_v1.json
@@ -144,6 +144,18 @@
         ],
         "type": "object"
       },
+      "Body_brain_stt_v1_brain_stt_post": {
+        "properties": {
+          "file": {
+            "format": "binary",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "type": "object"
+      },
       "STTResponse": {
         "properties": {
           "duration_seconds": {
@@ -410,16 +422,7 @@
           "content": {
             "multipart/form-data": {
               "schema": {
-                "properties": {
-                  "file": {
-                    "format": "binary",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "file"
-                ],
-                "type": "object"
+                "$ref": "#/components/schemas/Body_brain_stt_v1_brain_stt_post"
               }
             }
           },

--- a/services/echo_backend/models/brain_contract_v1.json
+++ b/services/echo_backend/models/brain_contract_v1.json
@@ -144,6 +144,101 @@
         ],
         "type": "object"
       },
+      "STTResponse": {
+        "properties": {
+          "duration_seconds": {
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          },
+          "ok": {
+            "type": "boolean"
+          },
+          "runtime": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RuntimeMetadata"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "type": "object"
+      },
+      "TTSRequest": {
+        "properties": {
+          "format": {
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "text": {
+            "maxLength": 4096,
+            "minLength": 1,
+            "type": "string"
+          },
+          "voice": {
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "type": "object"
+      },
+      "TTSResponse": {
+        "properties": {
+          "audio_base64": {
+            "type": "string"
+          },
+          "mime_type": {
+            "type": "string"
+          },
+          "ok": {
+            "type": "boolean"
+          },
+          "runtime": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RuntimeMetadata"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "audio_base64",
+          "mime_type"
+        ],
+        "type": "object"
+      },
       "RuntimeMetadata": {
         "properties": {
           "build_time": {
@@ -307,6 +402,93 @@
             }
           }
         }
+      }
+    },
+    "/v1/brain/stt": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "file": {
+                    "format": "binary",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "file"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/STTResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/v1/brain/tts": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TTSRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TTSResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
       }
     }
   }

--- a/services/echo_backend/tests/test_brain_contract_snapshot.py
+++ b/services/echo_backend/tests/test_brain_contract_snapshot.py
@@ -199,6 +199,8 @@ def test_all_brain_endpoints_in_snapshot(client, contract_snapshot_path):
         "/v1/brain/health",
         "/v1/brain/chat",
         "/v1/brain/chat/stream",
+        "/v1/brain/stt",
+        "/v1/brain/tts",
     }
     
     assert snapshot_paths == expected_endpoints, (

--- a/services/echo_backend/tests/test_brain_stt_stub.py
+++ b/services/echo_backend/tests/test_brain_stt_stub.py
@@ -132,9 +132,16 @@ def test_brain_stt_missing_file() -> None:
 
 def test_brain_stt_auth_required(monkeypatch) -> None:
     """Test STT requires authentication when AUTH_REQUIRED=true."""
+    # Clear settings cache before setting new values
+    from utils.auth.settings import get_auth_settings
+    get_auth_settings.cache_clear()
+    
     monkeypatch.setenv("AUTH_REQUIRED", "true")
     monkeypatch.setenv("AUTH_JWT_SECRET", "test-secret-key-minimum-32-chars!")
     monkeypatch.setenv("AUTH_PIN_HASH", "$2b$12$test")
+    
+    # Clear again after setting new values to force reload
+    get_auth_settings.cache_clear()
     
     from main import app
     
@@ -144,6 +151,9 @@ def test_brain_stt_auth_required(monkeypatch) -> None:
     files = {"file": ("test.webm", io.BytesIO(audio_content), "audio/webm")}
     
     resp = client.post("/v1/brain/stt", files=files)
+    
+    # Restore settings cache
+    get_auth_settings.cache_clear()
     
     assert resp.status_code == 401
     data = resp.json()

--- a/services/echo_backend/tests/test_brain_stt_stub.py
+++ b/services/echo_backend/tests/test_brain_stt_stub.py
@@ -1,0 +1,152 @@
+"""Tests for Brain API STT endpoint using stub provider."""
+import io
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(autouse=True)
+def force_stub_provider(monkeypatch):
+    """Force stub provider for all voice tests."""
+    monkeypatch.setenv("ECHO_VOICE_PROVIDER", "stub")
+    # Reset cached provider instance
+    from utils.brain.voice_provider import reset_voice_provider
+    reset_voice_provider()
+    yield
+    reset_voice_provider()
+
+
+def test_brain_stt_simple() -> None:
+    """Test simple STT transcription with stub provider."""
+    from main import app
+    
+    client = TestClient(app)
+    
+    # Create a fake audio file
+    audio_content = b"fake audio content for testing"
+    files = {"file": ("test.webm", io.BytesIO(audio_content), "audio/webm")}
+    
+    resp = client.post("/v1/brain/stt", files=files)
+    
+    assert resp.status_code == 200
+    data = resp.json()
+    
+    # Core response fields
+    assert data["ok"] is True
+    assert "text" in data
+    assert "stub" in data["text"].lower()
+    assert str(len(audio_content)) in data["text"]  # Should mention byte count
+    
+    # Duration should be present
+    assert "duration_seconds" in data
+    assert data["duration_seconds"] is not None
+    
+    # Runtime metadata fields
+    assert "runtime" in data
+    runtime = data["runtime"]
+    assert "trace_id" in runtime
+    assert len(runtime["trace_id"]) == 36  # UUID format
+    assert runtime["provider"] == "stub"
+    assert "env" in runtime
+    assert "git_sha" in runtime
+    assert "build_time" in runtime
+
+
+def test_brain_stt_wav_format() -> None:
+    """Test STT with WAV audio format."""
+    from main import app
+    
+    client = TestClient(app)
+    
+    audio_content = b"RIFF" + b"\x00" * 100  # Fake WAV header
+    files = {"file": ("recording.wav", io.BytesIO(audio_content), "audio/wav")}
+    
+    resp = client.post("/v1/brain/stt", files=files)
+    
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is True
+    assert "text" in data
+
+
+def test_brain_stt_mp3_format() -> None:
+    """Test STT with MP3 audio format."""
+    from main import app
+    
+    client = TestClient(app)
+    
+    audio_content = b"\xff\xfb\x90\x00" + b"\x00" * 100  # Fake MP3 header
+    files = {"file": ("recording.mp3", io.BytesIO(audio_content), "audio/mpeg")}
+    
+    resp = client.post("/v1/brain/stt", files=files)
+    
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is True
+
+
+def test_brain_stt_invalid_format() -> None:
+    """Test STT rejects invalid audio format."""
+    from main import app
+    
+    client = TestClient(app)
+    
+    files = {"file": ("test.txt", io.BytesIO(b"not audio"), "text/plain")}
+    
+    resp = client.post("/v1/brain/stt", files=files)
+    
+    assert resp.status_code == 400
+    data = resp.json()
+    detail = data["detail"]
+    assert detail["ok"] is False
+    assert detail["error"]["code"] == "invalid_audio_format"
+    assert "runtime" in detail
+
+
+def test_brain_stt_empty_file() -> None:
+    """Test STT rejects empty audio file."""
+    from main import app
+    
+    client = TestClient(app)
+    
+    files = {"file": ("empty.webm", io.BytesIO(b""), "audio/webm")}
+    
+    resp = client.post("/v1/brain/stt", files=files)
+    
+    assert resp.status_code == 400
+    data = resp.json()
+    detail = data["detail"]
+    assert detail["ok"] is False
+    assert detail["error"]["code"] == "empty_file"
+
+
+def test_brain_stt_missing_file() -> None:
+    """Test STT requires file parameter."""
+    from main import app
+    
+    client = TestClient(app)
+    
+    resp = client.post("/v1/brain/stt")
+    
+    assert resp.status_code == 422  # Validation error
+
+
+def test_brain_stt_auth_required(monkeypatch) -> None:
+    """Test STT requires authentication when AUTH_REQUIRED=true."""
+    monkeypatch.setenv("AUTH_REQUIRED", "true")
+    monkeypatch.setenv("AUTH_JWT_SECRET", "test-secret-key-minimum-32-chars!")
+    monkeypatch.setenv("AUTH_PIN_HASH", "$2b$12$test")
+    
+    from main import app
+    
+    client = TestClient(app)
+    
+    audio_content = b"test audio"
+    files = {"file": ("test.webm", io.BytesIO(audio_content), "audio/webm")}
+    
+    resp = client.post("/v1/brain/stt", files=files)
+    
+    assert resp.status_code == 401
+    data = resp.json()
+    detail = data["detail"]
+    assert detail["ok"] is False
+    assert detail["error"]["code"] == "auth_required"

--- a/services/echo_backend/tests/test_brain_tts_stub.py
+++ b/services/echo_backend/tests/test_brain_tts_stub.py
@@ -1,0 +1,182 @@
+"""Tests for Brain API TTS endpoint using stub provider."""
+import base64
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(autouse=True)
+def force_stub_provider(monkeypatch):
+    """Force stub provider for all voice tests."""
+    monkeypatch.setenv("ECHO_VOICE_PROVIDER", "stub")
+    # Reset cached provider instance
+    from utils.brain.voice_provider import reset_voice_provider
+    reset_voice_provider()
+    yield
+    reset_voice_provider()
+
+
+def test_brain_tts_simple() -> None:
+    """Test simple TTS synthesis with stub provider."""
+    from main import app
+    
+    client = TestClient(app)
+    payload = {"text": "Hello, this is a test message."}
+    
+    resp = client.post("/v1/brain/tts", json=payload)
+    
+    assert resp.status_code == 200
+    data = resp.json()
+    
+    # Core response fields
+    assert data["ok"] is True
+    assert "audio_base64" in data
+    assert len(data["audio_base64"]) > 0
+    assert "mime_type" in data
+    assert data["mime_type"] == "audio/mpeg"  # Default MP3
+    
+    # Verify base64 is valid
+    try:
+        decoded = base64.b64decode(data["audio_base64"])
+        assert len(decoded) > 0
+    except Exception as e:
+        pytest.fail(f"Invalid base64: {e}")
+    
+    # Runtime metadata fields
+    assert "runtime" in data
+    runtime = data["runtime"]
+    assert "trace_id" in runtime
+    assert len(runtime["trace_id"]) == 36  # UUID format
+    assert runtime["provider"] == "stub"
+    assert "env" in runtime
+    assert "git_sha" in runtime
+    assert "build_time" in runtime
+
+
+def test_brain_tts_with_voice() -> None:
+    """Test TTS with custom voice parameter."""
+    from main import app
+    
+    client = TestClient(app)
+    payload = {
+        "text": "Testing with custom voice.",
+        "voice": "echo"
+    }
+    
+    resp = client.post("/v1/brain/tts", json=payload)
+    
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is True
+
+
+def test_brain_tts_with_format() -> None:
+    """Test TTS with custom format parameter."""
+    from main import app
+    
+    client = TestClient(app)
+    payload = {
+        "text": "Testing with opus format.",
+        "format": "opus"
+    }
+    
+    resp = client.post("/v1/brain/tts", json=payload)
+    
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["mime_type"] == "audio/opus"
+
+
+def test_brain_tts_with_all_options() -> None:
+    """Test TTS with all optional parameters."""
+    from main import app
+    
+    client = TestClient(app)
+    payload = {
+        "text": "Full options test.",
+        "voice": "nova",
+        "format": "wav"
+    }
+    
+    resp = client.post("/v1/brain/tts", json=payload)
+    
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["mime_type"] == "audio/wav"
+
+
+def test_brain_tts_empty_text() -> None:
+    """Test TTS rejects empty text."""
+    from main import app
+    
+    client = TestClient(app)
+    payload = {"text": ""}
+    
+    resp = client.post("/v1/brain/tts", json=payload)
+    
+    # Pydantic validation should reject this (min_length=1)
+    assert resp.status_code == 422
+
+
+def test_brain_tts_missing_text() -> None:
+    """Test TTS requires text parameter."""
+    from main import app
+    
+    client = TestClient(app)
+    payload = {}
+    
+    resp = client.post("/v1/brain/tts", json=payload)
+    
+    assert resp.status_code == 422  # Validation error
+
+
+def test_brain_tts_long_text() -> None:
+    """Test TTS handles reasonably long text."""
+    from main import app
+    
+    client = TestClient(app)
+    # Create text near the limit (but under 4096)
+    long_text = "Hello world. " * 300  # ~3900 chars
+    payload = {"text": long_text}
+    
+    resp = client.post("/v1/brain/tts", json=payload)
+    
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is True
+
+
+def test_brain_tts_text_too_long() -> None:
+    """Test TTS rejects text exceeding max length."""
+    from main import app
+    
+    client = TestClient(app)
+    # Create text over the limit (>4096)
+    too_long_text = "A" * 5000
+    payload = {"text": too_long_text}
+    
+    resp = client.post("/v1/brain/tts", json=payload)
+    
+    # Pydantic validation should reject this (max_length=4096)
+    assert resp.status_code == 422
+
+
+def test_brain_tts_auth_required(monkeypatch) -> None:
+    """Test TTS requires authentication when AUTH_REQUIRED=true."""
+    monkeypatch.setenv("AUTH_REQUIRED", "true")
+    monkeypatch.setenv("AUTH_JWT_SECRET", "test-secret-key-minimum-32-chars!")
+    monkeypatch.setenv("AUTH_PIN_HASH", "$2b$12$test")
+    
+    from main import app
+    
+    client = TestClient(app)
+    payload = {"text": "Test authentication."}
+    
+    resp = client.post("/v1/brain/tts", json=payload)
+    
+    assert resp.status_code == 401
+    data = resp.json()
+    detail = data["detail"]
+    assert detail["ok"] is False
+    assert detail["error"]["code"] == "auth_required"

--- a/services/echo_backend/tests/test_brain_tts_stub.py
+++ b/services/echo_backend/tests/test_brain_tts_stub.py
@@ -164,9 +164,16 @@ def test_brain_tts_text_too_long() -> None:
 
 def test_brain_tts_auth_required(monkeypatch) -> None:
     """Test TTS requires authentication when AUTH_REQUIRED=true."""
+    # Clear settings cache before setting new values
+    from utils.auth.settings import get_auth_settings
+    get_auth_settings.cache_clear()
+    
     monkeypatch.setenv("AUTH_REQUIRED", "true")
     monkeypatch.setenv("AUTH_JWT_SECRET", "test-secret-key-minimum-32-chars!")
     monkeypatch.setenv("AUTH_PIN_HASH", "$2b$12$test")
+    
+    # Clear again after setting new values to force reload
+    get_auth_settings.cache_clear()
     
     from main import app
     
@@ -174,6 +181,9 @@ def test_brain_tts_auth_required(monkeypatch) -> None:
     payload = {"text": "Test authentication."}
     
     resp = client.post("/v1/brain/tts", json=payload)
+    
+    # Restore settings cache
+    get_auth_settings.cache_clear()
     
     assert resp.status_code == 401
     data = resp.json()

--- a/services/echo_backend/utils/brain/voice_provider.py
+++ b/services/echo_backend/utils/brain/voice_provider.py
@@ -1,0 +1,394 @@
+"""Voice provider interface and implementations for STT and TTS.
+
+Provides speech-to-text (STT) and text-to-speech (TTS) capabilities
+using OpenAI Audio API or stub implementations for testing.
+"""
+import base64
+import logging
+import os
+from abc import ABC, abstractmethod
+from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Configuration defaults
+DEFAULT_STT_MODEL = "gpt-4o-mini-transcribe"  # OpenAI's latest transcription model
+DEFAULT_TTS_MODEL = "gpt-4o-mini-tts"  # OpenAI's latest TTS model
+DEFAULT_TTS_VOICE = "alloy"  # Neutral, balanced voice
+DEFAULT_TTS_FORMAT = "mp3"  # Widely supported format
+DEFAULT_TIMEOUT = 60  # seconds
+
+# Format to MIME type mapping
+FORMAT_MIME_TYPES = {
+    "mp3": "audio/mpeg",
+    "opus": "audio/opus",
+    "aac": "audio/aac",
+    "flac": "audio/flac",
+    "wav": "audio/wav",
+    "pcm": "audio/pcm",
+}
+
+
+class VoiceProviderError(Exception):
+    """Base exception for voice provider errors."""
+    
+    def __init__(self, code: str, message: str, upstream_request_id: Optional[str] = None):
+        self.code = code
+        self.message = message
+        self.upstream_request_id = upstream_request_id
+        super().__init__(message)
+
+
+class VoiceProvider(ABC):
+    """Abstract interface for voice providers (STT + TTS)."""
+
+    @abstractmethod
+    async def transcribe(
+        self, 
+        audio_data: bytes, 
+        filename: str,
+        content_type: str,
+        trace_id: Optional[str] = None
+    ) -> Tuple[str, Optional[float]]:
+        """Transcribe audio to text.
+        
+        Args:
+            audio_data: Raw audio bytes.
+            filename: Original filename (for format detection).
+            content_type: MIME type of the audio.
+            trace_id: Optional trace ID for request correlation.
+            
+        Returns:
+            Tuple of (transcribed_text, duration_seconds).
+            
+        Raises:
+            VoiceProviderError: If transcription fails.
+        """
+        pass
+
+    @abstractmethod
+    async def synthesize(
+        self,
+        text: str,
+        voice: Optional[str] = None,
+        format: Optional[str] = None,
+        trace_id: Optional[str] = None
+    ) -> Tuple[bytes, str]:
+        """Synthesize text to speech.
+        
+        Args:
+            text: Text to convert to speech.
+            voice: Voice to use (provider-specific).
+            format: Output audio format.
+            trace_id: Optional trace ID for request correlation.
+            
+        Returns:
+            Tuple of (audio_bytes, mime_type).
+            
+        Raises:
+            VoiceProviderError: If synthesis fails.
+        """
+        pass
+
+
+class StubVoiceProvider(VoiceProvider):
+    """Stub provider for testing without external dependencies."""
+
+    async def transcribe(
+        self, 
+        audio_data: bytes, 
+        filename: str,
+        content_type: str,
+        trace_id: Optional[str] = None
+    ) -> Tuple[str, Optional[float]]:
+        """Return deterministic transcription for testing."""
+        # Log metadata only (never log audio content)
+        logger.debug(
+            f"STUB_STT_REQUEST trace_id={trace_id} "
+            f"audio_size={len(audio_data)} filename={filename}"
+        )
+        
+        # Return deterministic response based on audio size
+        text = f"Echo Voice (stub): transcribed {len(audio_data)} bytes of audio."
+        duration = len(audio_data) / 16000.0  # Assume 16kHz mono
+        
+        return text, duration
+
+    async def synthesize(
+        self,
+        text: str,
+        voice: Optional[str] = None,
+        format: Optional[str] = None,
+        trace_id: Optional[str] = None
+    ) -> Tuple[bytes, str]:
+        """Return deterministic audio for testing."""
+        # Log metadata only (never log text content)
+        logger.debug(
+            f"STUB_TTS_REQUEST trace_id={trace_id} "
+            f"text_length={len(text)} voice={voice} format={format}"
+        )
+        
+        # Return minimal valid audio placeholder (silence)
+        # This is a tiny valid MP3 frame representing silence
+        stub_audio = base64.b64decode(
+            "//uQxAAAAAANIAAAAAExBTUUzLjEwMFVVVVVVVVVVVVVVVVVV"
+            "VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV"
+        )
+        
+        output_format = format or DEFAULT_TTS_FORMAT
+        mime_type = FORMAT_MIME_TYPES.get(output_format, "audio/mpeg")
+        
+        return stub_audio, mime_type
+
+
+class OpenAIVoiceProvider(VoiceProvider):
+    """OpenAI-backed voice provider using Audio API.
+    
+    Features:
+    - STT via Whisper/gpt-4o-mini-transcribe
+    - TTS via gpt-4o-mini-tts
+    - Configurable models, voices, and formats via env vars
+    - Privacy: never logs audio bytes or transcribed text
+    """
+
+    def __init__(self):
+        """Initialize with lazy client."""
+        self._client = None
+        self._stt_model = os.environ.get("OPENAI_STT_MODEL", DEFAULT_STT_MODEL)
+        self._tts_model = os.environ.get("OPENAI_TTS_MODEL", DEFAULT_TTS_MODEL)
+        self._tts_voice = os.environ.get("OPENAI_TTS_VOICE", DEFAULT_TTS_VOICE)
+        self._tts_format = os.environ.get("OPENAI_TTS_FORMAT", DEFAULT_TTS_FORMAT)
+        self._timeout = float(os.environ.get("OPENAI_TIMEOUT", DEFAULT_TIMEOUT))
+
+    def _get_client(self):
+        """Lazy-init AsyncOpenAI client."""
+        if self._client is not None:
+            return self._client
+        
+        from openai import AsyncOpenAI
+        
+        api_key = os.environ.get("OPENAI_API_KEY")
+        if not api_key:
+            raise VoiceProviderError(
+                code="auth_error",
+                message="OPENAI_API_KEY not configured"
+            )
+        
+        self._client = AsyncOpenAI(
+            api_key=api_key,
+            timeout=self._timeout,
+            max_retries=2,
+        )
+        return self._client
+
+    def _map_error(self, e: Exception, upstream_request_id: Optional[str] = None) -> VoiceProviderError:
+        """Map OpenAI exceptions to VoiceProviderError."""
+        from openai import (
+            AuthenticationError,
+            RateLimitError,
+            APITimeoutError,
+            APIConnectionError,
+            BadRequestError,
+            APIStatusError,
+        )
+        
+        if isinstance(e, AuthenticationError):
+            return VoiceProviderError(
+                code="auth_error",
+                message="OpenAI authentication failed. Check API key.",
+                upstream_request_id=upstream_request_id
+            )
+        elif isinstance(e, RateLimitError):
+            return VoiceProviderError(
+                code="rate_limit",
+                message="OpenAI rate limit exceeded. Please retry later.",
+                upstream_request_id=upstream_request_id
+            )
+        elif isinstance(e, APITimeoutError):
+            return VoiceProviderError(
+                code="timeout",
+                message=f"OpenAI request timed out after {self._timeout}s.",
+                upstream_request_id=upstream_request_id
+            )
+        elif isinstance(e, APIConnectionError):
+            return VoiceProviderError(
+                code="connection_error",
+                message="Failed to connect to OpenAI API.",
+                upstream_request_id=upstream_request_id
+            )
+        elif isinstance(e, BadRequestError):
+            return VoiceProviderError(
+                code="bad_request",
+                message=f"Invalid request to OpenAI: {str(e)}",
+                upstream_request_id=upstream_request_id
+            )
+        elif isinstance(e, APIStatusError):
+            return VoiceProviderError(
+                code="upstream_error",
+                message=f"OpenAI API error (HTTP {e.status_code}): {str(e)}",
+                upstream_request_id=upstream_request_id
+            )
+        else:
+            return VoiceProviderError(
+                code="unknown_error",
+                message=f"Unexpected error: {str(e)}",
+                upstream_request_id=upstream_request_id
+            )
+
+    async def transcribe(
+        self, 
+        audio_data: bytes, 
+        filename: str,
+        content_type: str,
+        trace_id: Optional[str] = None
+    ) -> Tuple[str, Optional[float]]:
+        """Transcribe audio using OpenAI Whisper/transcription API."""
+        client = self._get_client()
+        upstream_request_id = None
+        
+        # Log metadata only (never log audio content for privacy)
+        logger.info(
+            f"OPENAI_STT_REQUEST trace_id={trace_id} "
+            f"audio_size={len(audio_data)} model={self._stt_model}"
+        )
+        
+        try:
+            # Create file-like object for upload
+            from io import BytesIO
+            audio_file = BytesIO(audio_data)
+            audio_file.name = filename
+            
+            response = await client.audio.transcriptions.create(
+                model=self._stt_model,
+                file=audio_file,
+            )
+            
+            # Extract text from response
+            text = response.text
+            duration = getattr(response, 'duration', None)
+            
+            logger.info(
+                f"OPENAI_STT_SUCCESS trace_id={trace_id} "
+                f"text_length={len(text)} duration={duration}"
+            )
+            
+            return text, duration
+            
+        except VoiceProviderError:
+            raise
+        except Exception as e:
+            logger.error(
+                f"OPENAI_STT_ERROR trace_id={trace_id} "
+                f"error_type={type(e).__name__}"
+            )
+            raise self._map_error(e, upstream_request_id)
+
+    async def synthesize(
+        self,
+        text: str,
+        voice: Optional[str] = None,
+        format: Optional[str] = None,
+        trace_id: Optional[str] = None
+    ) -> Tuple[bytes, str]:
+        """Synthesize speech using OpenAI TTS API."""
+        client = self._get_client()
+        upstream_request_id = None
+        
+        output_voice = voice or self._tts_voice
+        output_format = format or self._tts_format
+        mime_type = FORMAT_MIME_TYPES.get(output_format, "audio/mpeg")
+        
+        # Log metadata only (never log text content for privacy)
+        logger.info(
+            f"OPENAI_TTS_REQUEST trace_id={trace_id} "
+            f"text_length={len(text)} voice={output_voice} format={output_format}"
+        )
+        
+        try:
+            response = await client.audio.speech.create(
+                model=self._tts_model,
+                voice=output_voice,
+                input=text,
+                response_format=output_format,
+            )
+            
+            # Read audio bytes from response
+            audio_bytes = response.content
+            
+            logger.info(
+                f"OPENAI_TTS_SUCCESS trace_id={trace_id} "
+                f"audio_size={len(audio_bytes)}"
+            )
+            
+            return audio_bytes, mime_type
+            
+        except VoiceProviderError:
+            raise
+        except Exception as e:
+            logger.error(
+                f"OPENAI_TTS_ERROR trace_id={trace_id} "
+                f"error_type={type(e).__name__}"
+            )
+            raise self._map_error(e, upstream_request_id)
+
+
+# Provider registry and selection logic
+_voice_provider_instance: Optional[VoiceProvider] = None
+
+
+def get_voice_provider() -> VoiceProvider:
+    """Get the configured voice provider instance.
+    
+    Selection logic:
+    1. If ECHO_VOICE_PROVIDER explicitly set -> use it
+    2. Else if OPENAI_API_KEY exists -> openai provider
+    3. Else -> stub provider (for CI/testing)
+    
+    Returns:
+        VoiceProvider instance (cached after first call).
+    """
+    global _voice_provider_instance
+    
+    if _voice_provider_instance is not None:
+        return _voice_provider_instance
+    
+    # Check explicit provider override
+    provider_name = os.environ.get('ECHO_VOICE_PROVIDER', '').lower()
+    
+    if provider_name == 'stub':
+        _voice_provider_instance = StubVoiceProvider()
+        return _voice_provider_instance
+    
+    if provider_name == 'openai':
+        if not os.environ.get('OPENAI_API_KEY'):
+            raise RuntimeError(
+                "ECHO_VOICE_PROVIDER=openai but OPENAI_API_KEY not set. "
+                "Provide the key or use ECHO_VOICE_PROVIDER=stub for testing."
+            )
+        _voice_provider_instance = OpenAIVoiceProvider()
+        return _voice_provider_instance
+    
+    # Auto-selection based on OPENAI_API_KEY availability
+    if os.environ.get('OPENAI_API_KEY'):
+        _voice_provider_instance = OpenAIVoiceProvider()
+    else:
+        # Fallback to stub for CI/testing
+        _voice_provider_instance = StubVoiceProvider()
+    
+    return _voice_provider_instance
+
+
+def get_voice_provider_name() -> str:
+    """Get the name of the active voice provider."""
+    provider = get_voice_provider()
+    if isinstance(provider, StubVoiceProvider):
+        return "stub"
+    elif isinstance(provider, OpenAIVoiceProvider):
+        return "openai"
+    return "unknown"
+
+
+def reset_voice_provider() -> None:
+    """Reset the cached provider instance. Used for testing."""
+    global _voice_provider_instance
+    _voice_provider_instance = None

--- a/services/echo_backend/utils/brain/voice_provider.py
+++ b/services/echo_backend/utils/brain/voice_provider.py
@@ -128,12 +128,9 @@ class StubVoiceProvider(VoiceProvider):
             f"text_length={len(text)} voice={voice} format={format}"
         )
         
-        # Return minimal valid audio placeholder (silence)
-        # This is a tiny valid MP3 frame representing silence
-        stub_audio = base64.b64decode(
-            "//uQxAAAAAANIAAAAAExBTUUzLjEwMFVVVVVVVVVVVVVVVVVV"
-            "VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV"
-        )
+        # Return minimal stub audio bytes (not actually valid MP3, but works for testing)
+        # Use simple bytes that will encode to valid base64
+        stub_audio = b"STUB_AUDIO_DATA_FOR_TESTING_PURPOSES_1234567890"
         
         output_format = format or DEFAULT_TTS_FORMAT
         mime_type = FORMAT_MIME_TYPES.get(output_format, "audio/mpeg")


### PR DESCRIPTION
## Summary
Voice v1 enables speech-to-text input and text-to-speech output for Echo Chat.

## Features
- **STT (Speech-to-Text)**: Record audio via mic button → transcribe via OpenAI → send to chat
- **TTS (Text-to-Speech)**: AI response → synthesize audio → auto-play

## Backend Changes
- \POST /v1/brain/stt\ - Audio file → transcribed text
- \POST /v1/brain/tts\ - Text → base64 audio
- OpenAI Audio API integration (gpt-4o-mini-transcribe, gpt-4o-mini-tts)
- Stub provider for CI testing (no API key needed)

## Web Changes
- VoiceButton component with recording states
- useVoice hook for MediaRecorder + TTS playback
- Auto-play toggle (🔊) in header
- Mic button in chat input area

## Env Vars
| Variable | Default | Description |
|----------|---------|-------------|
| OPENAI_STT_MODEL | gpt-4o-mini-transcribe | STT model |
| OPENAI_TTS_MODEL | gpt-4o-mini-tts | TTS model |
| OPENAI_TTS_VOICE | alloy | Default voice |
| OPENAI_TTS_FORMAT | mp3 | Audio format |

## Testing on Staging
1. Go to https://echo-web-staging-zxuvsjb5qa-ew.a.run.app
2. Login with PIN
3. Click 🎤 mic button → speak → click again to stop
4. Your speech is transcribed and sent to chat
5. Enable 🔊 toggle → AI responses play as audio

## Files Changed
- Backend: models/brain.py, routers/brain.py, utils/brain/voice_provider.py
- Tests: test_brain_stt_stub.py, test_brain_tts_stub.py
- Web: VoiceButton.tsx, useVoice.ts, App.tsx, Header.tsx
- Docs: docs/ops/voice_v1.md, README.md

Co-Authored-By: Warp <agent@warp.dev>