### PR TITLE
ci: add web app CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,38 @@ jobs:
   # Omi-based codebase validation
   # Note: Full tests require Firebase/Modal setup - see docs/ARCHITECTURE.md
 
+  web:
+    name: Web (lint + typecheck + test + build)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/web
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: apps/web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Test
+        run: npm run test --if-present
+
+      - name: Build
+        run: npm run build
+
   backend:
     name: Backend (lint + unit/smoke tests)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Add CI checks for the web app (apps/web) to ensure code quality before merging to main.

## Changes
- Add new 'Web (lint + typecheck + test + build)' job to CI workflow
- Uses Node.js 24 (matching Vercel production)
- Runs: lint, typecheck, test (if present), build
- Enables npm caching for faster builds

## Checklist
- [x] CI workflow updated
- [x] Uses stable job name for required status checks

Co-Authored-By: Warp <agent@warp.dev>